### PR TITLE
Ignore non-existing index patterns

### DIFF
--- a/src/main/java/com/getindata/flink/connector/jdbc/catalog/IndexFilterResolver.java
+++ b/src/main/java/com/getindata/flink/connector/jdbc/catalog/IndexFilterResolver.java
@@ -43,17 +43,17 @@ class IndexFilterResolver {
     boolean isAccepted(String objectName) {
         if (!includePatterns.isEmpty()) {
             if (includePatterns.stream().noneMatch(pattern -> pattern.matcher(objectName).matches())) {
-                LOG.info("'{}' does not match any include pattern. Include patterns='{}'.", objectName, includePatterns);
+                LOG.debug("'{}' does not match any include pattern. Include patterns='{}'.", objectName, includePatterns);
                 return false;
             }
         }
         if (!excludePatterns.isEmpty()) {
             if (excludePatterns.stream().anyMatch(pattern -> pattern.matcher(objectName).matches())) {
-                LOG.info("'{}' matches exclude pattern; exclude patterns='{}'.", objectName, excludePatterns);
+                LOG.debug("'{}' matches exclude pattern; exclude patterns='{}'.", objectName, excludePatterns);
                 return false;
             }
         }
-        LOG.info("'{}' matches include pattern and does not match any exclude pattern.", objectName);
+        LOG.debug("'{}' matches include pattern and does not match any exclude pattern.", objectName);
         return true;
     }
 

--- a/src/test/java/com/getindata/flink/connector/jdbc/catalog/ElasticCatalogITCase.java
+++ b/src/test/java/com/getindata/flink/connector/jdbc/catalog/ElasticCatalogITCase.java
@@ -28,8 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-
 public class ElasticCatalogITCase extends ElasticCatalogTestBase {
+
     private static final String INPUT_SINGLE_RECORD_TABLE = "test_single_record_table";
     private static final String INPUT_MULTIPLE_RECORDS_TABLE = "test_multiple_records_table";
     private static final String INPUT_MISSING_DATE_COL_TABLE = "test_missing_date_col_table";
@@ -99,11 +99,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     }
 
     @Test
-    public void testListDatabases() throws DatabaseNotExistException, TableNotExistException {
-        // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-
+    public void testListDatabases() {
         // when
         ElasticCatalog catalog = catalogBuilder().build();
 
@@ -114,11 +110,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     }
 
     @Test
-    public void testListTables() throws DatabaseNotExistException, InterruptedException {
-        // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-
+    public void testListTables() throws DatabaseNotExistException {
         // when
         ElasticCatalog catalog = catalogBuilder().build();
 
@@ -140,10 +132,6 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
 
     @Test
     public void testTableFiltering() throws DatabaseNotExistException {
-        // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-
         // when
         ElasticCatalog catalog = catalogBuilder()
                 .indexFilterResolver(IndexFilterResolver.of("test_m.*", "test_mi.*"))
@@ -159,11 +147,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     }
 
     @Test
-    public void testTableExists() throws DatabaseNotExistException {
-        // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-
+    public void testTableExists() {
         // when
         ElasticCatalog catalog = catalogBuilder().build();
 
@@ -193,10 +177,6 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
 
     @Test
     public void testGetNonPartitionedTable() throws TableNotExistException {
-        // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-
         // when
         ElasticCatalog catalog = catalogBuilder().build();
         CatalogBaseTable table = catalog.getTable(new ObjectPath(
@@ -214,9 +194,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     @Test
     public void testGetTablePartitionedByTimestamp() throws TableNotExistException {
         // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("properties.scan.test_multiple_records_table.partition.column.name", "date_col");
         properties.put("properties.scan.test_multiple_records_table.partition.number", "10");
 
@@ -238,9 +216,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     @Test
     public void testGetTablePartitionedByInteger() throws TableNotExistException {
         // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("properties.scan.test_multiple_records_table.partition.column.name", "integer_col");
         properties.put("properties.scan.test_multiple_records_table.partition.number", "10");
 
@@ -262,9 +238,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     @Test
     public void testGetTableDefaultScanOptionsZeroRecords() throws TableNotExistException {
         // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("catalog.default.scan.partition.column.name", "date_col");
         properties.put("catalog.default.scan.partition.size", "100");
 
@@ -287,9 +261,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     @Test
     public void testFailNoPartitionColumnProvided() throws TableNotExistException {
         // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("properties.scan.test_multiple_records_table.partition.number", "10");
 
         // when
@@ -307,9 +279,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     @Test
     public void testFailNoPartitionNumberProvided() throws TableNotExistException {
         // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("properties.scan.test_multiple_records_table.partition.column.name", "date_col");
 
         // when
@@ -327,9 +297,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     @Test
     public void testFailNoPartitionColumnInTable() throws TableNotExistException {
         // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("properties.scan.test_missing_date_col_table.partition.column.name", "date_col");
         properties.put("properties.scan.test_missing_date_col_table.partition.number", "10");
 
@@ -348,9 +316,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     @Test
     public void testFailPartitionColumnNotSupported() throws TableNotExistException {
         // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("properties.scan.test_single_record_table.partition.column.name", "keyword_col");
         properties.put("properties.scan.test_single_record_table.partition.number", "10");
 
@@ -369,9 +335,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     @Test
     public void testFailInappropriatePartitionNumber() throws TableNotExistException {
         // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("properties.scan.test_multiple_records_table.partition.column.name", "date_col");
         properties.put("properties.scan.test_multiple_records_table.partition.number", "0");
 
@@ -390,10 +354,6 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     @Disabled
     @Test
     public void testUnsupportedDataTypeInTable() throws TableNotExistException {
-        // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-
         // when
         ElasticCatalog catalog = catalogBuilder().build();
         try {
@@ -409,9 +369,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     @Test
     public void testGetTableDefaultCatalogScanPartitionProperties() throws TableNotExistException {
         // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("catalog.default.scan.partition.column.name", "date_col");
         properties.put("catalog.default.scan.partition.size", "5");
 
@@ -432,9 +390,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     @Test
     public void testGetTableOverwriteCatalogScanProperties() throws TableNotExistException {
         // given
-        String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
-                container.getElasticPort());
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("properties.scan.test_multiple_records_table.partition.column.name", "integer_col");
         properties.put("properties.scan.test_multiple_records_table.partition.number", "3");
         properties.put("catalog.default.scan.partition.column.name", "date_col");
@@ -458,7 +414,7 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
         // given
         String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
                 container.getElasticPort());
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("properties.index.patterns", "test_*_record_table");
 
         // when
@@ -511,11 +467,24 @@ public class ElasticCatalogITCase extends ElasticCatalogTestBase {
     }
 
     @Test
+    public void testShouldIgnoreNonexistingIndexPattern() {
+        // given
+        Map<String, String> properties = new HashMap<>();
+        properties.put("properties.index.patterns", "non_existing_pattern*");
+
+        // when
+        catalogBuilder().properties(properties).build();
+
+        // then
+        // no exception thrown
+    }
+
+    @Test
     public void testGetMultipleIndexPatternPartitionedTables() throws TableNotExistException, DatabaseNotExistException {
         // given
         String url = String.format("jdbc:elasticsearch://%s:%d", container.getHost(),
                 container.getElasticPort());
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, String> properties = new HashMap<>();
         properties.put("properties.scan.test_*_record*_table.partition.column.name", "date_col");
         properties.put("properties.scan.test_*_record*_table.partition.number", "10");
         properties.put("properties.scan.test_partial_schema_table_*.partition.column.name", "integer_col");

--- a/src/test/java/com/getindata/flink/connector/jdbc/catalog/ElasticCatalogTestBase.java
+++ b/src/test/java/com/getindata/flink/connector/jdbc/catalog/ElasticCatalogTestBase.java
@@ -107,6 +107,18 @@ class ElasticCatalogTestBase {
             assertTrue(response.isSuccessful());
         }
     }
+    protected static void deleteTestIndex(String inputTable) throws Exception {
+        OkHttpClient client = new OkHttpClient();
+        Request request = new Request.Builder()
+                .url(String.format("http://%s:%d/%s/", container.getHost(),
+                        container.getElasticPort(), inputTable))
+                .delete()
+                .addHeader("Authorization", Credentials.basic(USERNAME, PASSWORD))
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            assertTrue(response.isSuccessful());
+        }
+    }
 
     protected static void addTestData(String inputTable, String inputPath) throws Exception {
         OkHttpClient client = new OkHttpClient();


### PR DESCRIPTION
If index pattern does not exist, an error is logged instead of failing the entire job.